### PR TITLE
Modularize the Mongoose and SQL into adapters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,16 @@ var _ = require('lodash')
 var autoParse = require('auto-parse')
 // var setOrGet = require('set-or-get')
 var auto = require('run-auto')
+var util = require('./lib/util')
+var fs = require('fs')
+var Path = require('path')
+
+var DEFAULT_OPTIONS = require('./lib/options.js')
+var PATHadapterS = __dirname + '/lib/adapters'
+
+var adapterNames = fs.readdirSync(PATHadapterS).map(function (c) {
+  return c.slice(0, -3)
+})
 
 function autoSync (tasks, cb) {
   var result = {}
@@ -27,12 +37,22 @@ function autoSync (tasks, cb) {
 
 function Build (options) {
   var self = this
-  self.options = _.merge(require('./lib/options.js'), options)
+
+  self.options = _.merge(_.cloneDeep(DEFAULT_OPTIONS), options)
+  self.adapter = null
+
+  // Handle the adapters
+  if (self.options.settings.adapter) {
+    self.adapter = self.getAdapter(self.options.settings.adapter)
+  }
+
   self.schema = self.options.settings.schema ? _.uniq(self.options.settings.schema) : []
+
   self.schemaSort = []
   _.forEach(self.schema, function (key) {
     self.schemaSort.push(key, '-' + key)
   })
+
   self.tasks = function (query) {
     return {
       filter: function (cb) {
@@ -50,145 +70,57 @@ function Build (options) {
         cb(null, query.skip ? autoParse(query.skip) : self.options.query.skip)
       },
       sort: function (cb) {
-        cb(null, query.sort ? sortCheck(query.sort) : self.options.query.sort)
+        cb(null, query.sort ? util.sortCheck(query.sort) : self.options.query.sort)
       },
       limit: function (cb) {
-        cb(null, query.limit ? limitCheck(query.limit, self.options.query.limit) : self.options.query.limit)
+        cb(null, query.limit ? util.limitCheck(query.limit, self.options.query.limit) : self.options.query.limit)
       },
       select: function (cb) {
-        cb(null, query.select ? selectCheck(query.select, self.schema) : self.options.query.select)
-      }
-    }
-  }
-  self.mongoose = function (query) {
-    var where = {
-      used: false,
-      parameters: {}
-    }
-    function whereParameter (check, type) {
-      if (!_.isUndefined(check)) {
-        where.used = true
-        where.parameters[type] = check
-        return check
-      }
-      return false
-    }
-    return {
-      lean: function (cb) {
-        cb(null, query.lean ? autoParse(query.lean) : self.options.query.lean)
-      },
-      gt: function (cb) {
-        cb(null, query.gt ? whereParameter(query.gt, '$gt') : self.options.mongoose.gt)
-      },
-      lt: function (cb) {
-        cb(null, query.lt ? whereParameter(query.lt, '$lt') : self.options.mongoose.lt)
-      },
-      gte: function (cb) {
-        cb(null, query.gte ? whereParameter(query.gte, '$gte') : self.options.mongoose.gte)
-      },
-      lte: function (cb) {
-        cb(null, query.lte ? whereParameter(query.lte, '$lte') : self.options.mongoose.lte)
-      },
-      in: function (cb) {
-        cb(null, query.in ? whereParameter(query.in, '$in') : self.options.mongoose.in)
-      },
-      ne: function (cb) {
-        cb(null, query.ne ? whereParameter(query.ne, '$ne') : self.options.mongoose.ne)
-      },
-      nin: function (cb) {
-        cb(null, query.nin ? whereParameter(query.nin, '$nin') : self.options.mongoose.nin)
-      },
-      regex: function (cb) {
-        cb(null, query.regex ? whereParameter(query.regex, '$regex') : self.options.mongoose.regex)
-      },
-      options: function (cb) {
-        cb(null, query.options ? whereParameter(query.options, '$options') : self.options.mongoose.options)
-      },
-      size: function (cb) {
-        cb(null, query.size ? whereParameter(query.size, '$size') : self.options.mongoose.size)
-      },
-      all: function (cb) {
-        cb(null, query.all ? whereParameter(query.all, '$all') : self.options.mongoose.all)
-      },
-      equals: function (cb) {
-        cb(null, query.equals ? whereParameter(query.equals, '$equals') : self.options.mongoose.equals)
-      },
-      find: function (cb) {
-        cb(null, query.find ? whereParameter(query.find, 'find') : self.options.mongoose.find)
-      },
-      or: function (cb) {
-        cb(null, query.or ? andOrNorParameter(query.or, '$or') : self.options.mongoose.or)
-      },
-      nor: function (cb) {
-        cb(null, query.nor ? andOrNorParameter(query.nor, '$nor') : self.options.mongoose.nor)
-      },
-      and: function (cb) {
-        cb(null, query.and ? andOrNorParameter(query.and, '$and') : self.options.mongoose.and)
-      },
-      aggregate: function (cb) {
-        cb(null, query.aggregate ? aggregateCheck(query.aggregate) : self.options.mongoose.aggregate)
-      },
-      populateId: function (cb) {
-        cb(null, query.populateId ? populateCheck(query.populateId, self.options, 'populateId') : self.options.mongoose.populateId) // models
-      },
-      populateItems: function (cb) {
-        cb(null, query.populateItems ? populateCheck(query.populateItems, self.options, 'populateItems') : self.options.mongoose.populateItems) // settings.schema
-      },
-      deepPopulate: function (cb) {
-        cb(null, query.deepPopulate ? query.deepPopulate : self.options.mongoose.deepPopulate) // add settings.schema check for deepPop
-      },
-      where: function (cb) {
-        cb(null, query.where || {})
-      },
-      whereParameters: function (cb) {
-        cb(null, where)
-      }
-    }
-  }
-  self.sql = function (query) {
-    return {
-      sql: function (cb) {
-        cb(null, null)
+        cb(null, query.select ? util.selectCheck(query.select, self.schema) : self.options.query.select)
       }
     }
   }
 }
 
+Build.prototype.getAdapter = function (name) {
+  if (typeof name === 'string') {
+    if (_.includes(adapterNames, name)) {
+      return require(Path.join(PATHadapterS, name))
+    }
+    throw new Error('Adapter "' + name + '" does not exist. Provide an object to use a custom adapter.')
+  }
+  return name
+}
+
 Build.prototype.config = function (data) {
   var self = this
-  if (data)self.options = _.merge(self.options, data)
+  if (data) self.options = _.merge(self.options, data)
   return self.options
 }
+
 Build.prototype.parse = function (parse, cb) {
   var options = this.options
   var defaults = _.cloneDeep(this.options.query)
-  if (this.options.settings.mongoose) _.merge(defaults, options.mongoose)
-  if (this.options.settings.sql) _.merge(defaults, options.sql)
+
+  _.merge(defaults, this.adapter.options)
+
   var self = this
   if (_.isEmpty(parse)) {
     if (cb) return cb(defaults)
     return defaults
   }
   parse = autoParse(parse)
+
   var tasks = self.tasks(parse)
-  if (this.options.settings.mongoose) _.merge(tasks, self.mongoose(parse))
-  if (this.options.settings.sql) _.merge(tasks, self.sql(parse))
+
+  _.merge(tasks, self.adapter(parse))
+
   var response = autoSync(
     tasks
     , function (err, result) {
       if (err) console.log(err)
-      if (options.settings.mongoose) {
-        if (result.whereParameters.used) {
-          // result.where = result.whereParameters
-          // call function
-          if (!_.isArray(result.where)) {
-            result.where = whereObject(result.where, result.whereParameters.parameters, options.settings.schema)
-          } else {
-            result.where = whereObject(result.where[0] || '', result.whereParameters.parameters, options.settings.schema)
-            console.log('The Where selector appears to be the problem. Looks like we got a multiple wheres but expect a where', 'Where', err)
-          }
-        }
-        delete result.whereParameters
+      if (typeof self.adapter.afterParse === 'function') {
+        self.adapter.afterParse.call(self, result, options)
       }
       return _.merge(defaults, result)
     })
@@ -198,6 +130,7 @@ Build.prototype.parse = function (parse, cb) {
     return response
   }
 }
+
 Build.prototype.query = function (params) {
   var options = this.options
   var self = this
@@ -210,8 +143,9 @@ Build.prototype.query = function (params) {
     }
 
     var tasks = self.tasks(req.query)
-    if (this.options.settings.mongoose) _.merge(tasks, self.mongoose(req.query))
-    if (this.options.settings.sql) _.merge(tasks, self.sql(req.query))
+
+    _.merge(tasks, self.adapter(req.query))
+
     auto(
       tasks
       , function (err, result) {
@@ -221,156 +155,6 @@ Build.prototype.query = function (params) {
       })
   } // END OF RETURN
 } // END OF QUERY
-
-function limitCheck (number, limit) {
-  number = number << 0
-  if (!number || number > limit || number === 0) {
-    number = limit
-  }
-  return number
-}
-function sortCheck (sort) {
-  // V Year  ^ Title        ^ ...
-  //   1995    Bob           2
-  //   1995    Bob           1
-  //   1995    Alice
-  //   1995    AAA
-  //
-  //   1993    Carol
-  //   1993    Bob
-  //
-  //   1992    Dave
-  //
-  // sort=year&sort=-title
-  //
-  // sort: ["year", "-title"]
-  // .sort([
-  //  ["year", 1],
-  //  ["title", -1]
-  // ])
-  if (_.isArray(sort)) {
-    return _.map(sort, function (current) {
-      var direction = 1
-      if (_.startsWith(current, '-')) {
-        direction = -1
-        current = current.slice(1)
-      }
-      return [current, direction]
-    })
-  }
-  return sort
-}
-
-function selectCheck (select, schema) {
-  var selected = {}
-  select = _.isArray(select) ? select : select.split(' ')
-
-  _.forEach(select, function (current) {
-    if (!_.includes(schema, current)) {
-      return
-    }
-
-    var enabled = 1
-    if (_.startsWith(current, '-')) {
-      enabled = 0
-      current = current.slice(1)
-    }
-    selected[current] = enabled
-  })
-
-  return selected
-}
-
-function andOrNorParameter (data, type) {
-  if (data) {
-    var queryParameters = {}
-    queryParameters[type] = []
-    _.forEach(data, function (o, key) {
-      _.forEach(o, function (d) {
-        var obj = {}
-        obj[key] = autoParse(d)
-        queryParameters[type].push(obj)
-      })
-    })
-    return queryParameters
-  } else {
-    return false
-  }
-}
-
-function aggregateCheck (aggregated) {
-  var output = []
-
-  _.forEach(aggregated, function (n, key) {
-    var aggregate = {}
-    aggregate[key] = autoParse(n) // valueParse(n)
-    output.push(aggregate)
-  })
-  return output
-}
-
-function populateCheck (data, options, type) {
-  var defaults = options.mongoose
-  var output = ''
-  if (!_.isArray(data)) {
-    data = data.replace(',', ' ').split(' ')
-  }
-  var defaultIds = []
-  if (!_.isArray(defaults[type])) {
-    defaultIds = defaults[type].replace(',', ' ').split(' ')
-  }
-  if (defaults[type]) {
-    data = _.union(data, defaultIds)
-  }
-  _.forEach(data, function (n, key) {
-    if (_.includes(options.settings.schema, n)) {
-      output += n + ' '
-    }
-  })
-  return _.trim(output)
-}
-
-function whereObject (where, whereParameters, schema) {
-  var output = {}
-  output[where] = {}
-  _.forEach(whereParameters, function (n, key) {
-    if (key === '$equals') {
-      try {
-        output[where] = autoParse(n) // valueParser(settings.schemas[settings.modelNameCheck(_.replace(req.path, settings.options.routing.url, ''))].paths[where].instance, n)
-      } catch (err) {
-        console.log(where + '- The Where selector appears to be the problem', 'Where$equals', err)
-      }
-    } else if (key === 'find') {
-      if (schema.indexOf(where) !== -1) {
-        output[where] = autoParse(n) // new RegExp(_.escapeRegExp(autoParse(n)), 'i')
-      } else {
-        console.log(where + '- The Where Find is not in the schema - strict mode on ', 'WhereFind', 'err')
-      }
-    } else if (key === '$nin' || key === '$in' || key === '$all') {
-      try {
-        if (_.isArray(n)) {
-          if (schema.indexOf(where) !== -1) {
-            output[where][key] = autoParse(n)
-          } else {
-            console.log(where + '- The Where $nin $in $all is not in the schema - strict mode on ', 'Whereinall', 'err')
-          }
-        } else {
-          if (schema.indexOf(where) !== -1) {
-            output[where][key] = [autoParse(n)]
-          } else {
-            console.log(where + '- The Where $nin $in $all is not in the schema - strict mode on ', 'WhereEinall', 'err')
-          }
-        }
-      } catch (err) {
-        console.log(where + '- The Where selector appears to be the problem', 'Where-all', err)
-      }
-    } else {
-      output[where][key] = autoParse(n)
-    }
-  })
-
-  return output
-}
 
 function build (options) {
   if (options === undefined || (typeof options === 'object' && options !== null)) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 var _ = require('lodash')
 var autoParse = require('auto-parse')
 // var setOrGet = require('set-or-get')
-var auto = require('run-auto')
 var util = require('./lib/util')
 var fs = require('fs')
 var Path = require('path')
@@ -131,30 +130,13 @@ Build.prototype.parse = function (parse, cb) {
   }
 }
 
-Build.prototype.query = function (params) {
-  var options = this.options
+Build.prototype.middleware = function () {
   var self = this
-  if (params) options = _.merge(options, params)
-
   return function (res, req, next) {
-    if (_.isEmpty(req.query)) {
-      req.queryParameters = options
-      return next()
-    }
-
-    var tasks = self.tasks(req.query)
-
-    _.merge(tasks, self.adapter(req.query))
-
-    auto(
-      tasks
-      , function (err, result) {
-        if (err) console.log(err)
-        req.queryParameters = _.merge(options, result)
-        return next()
-      })
-  } // END OF RETURN
-} // END OF QUERY
+    req.queryParameters = self.parse(req.query)
+    next()
+  }
+}
 
 function build (options) {
   if (options === undefined || (typeof options === 'object' && options !== null)) {

--- a/lib/adapters/mongoose.js
+++ b/lib/adapters/mongoose.js
@@ -1,0 +1,182 @@
+var _ = require('lodash')
+var util = require('../util')
+var autoParse = require('auto-parse')
+
+var OPTIONS = {
+  populateId: '',
+  populateItems: '',
+  limitToPopulateId: '',
+  limitToPopulateItems: '',
+  deepPopulate: '',
+  where: '',
+  gt: false,
+  gte: false,
+  lte: false,
+  lt: false,
+  in: false,
+  ne: false,
+  nin: false,
+  regex: false,
+  options: false,
+  size: false,
+  all: false,
+  equals: false,
+  find: false,
+  or: false,
+  nor: false,
+  and: false
+}
+
+function andOrNorParameter (data, type) {
+  if (data) {
+    var queryParameters = {}
+    queryParameters[type] = []
+    _.forEach(data, function (o, key) {
+      _.forEach(o, function (d) {
+        var obj = {}
+        obj[key] = autoParse(d)
+        queryParameters[type].push(obj)
+      })
+    })
+    return queryParameters
+  } else {
+    return false
+  }
+}
+
+function aggregateCheck (aggregated) {
+  var output = []
+
+  _.forEach(aggregated, function (n, key) {
+    var aggregate = {}
+    aggregate[key] = autoParse(n) // valueParse(n)
+    output.push(aggregate)
+  })
+  return output
+}
+
+function populateCheck (data, options, type) {
+  var defaults = this.adapter.options
+  var output = ''
+  if (!_.isArray(data)) {
+    data = data.replace(',', ' ').split(' ')
+  }
+  var defaultIds = []
+  if (!_.isArray(defaults[type])) {
+    defaultIds = defaults[type].replace(',', ' ').split(' ')
+  }
+  if (defaults[type]) {
+    data = _.union(data, defaultIds)
+  }
+  _.forEach(data, function (n, key) {
+    if (_.includes(options.settings.schema, n)) {
+      output += n + ' '
+    }
+  })
+  return _.trim(output)
+}
+
+function MongooseAdapter (query) {
+  var self = this
+  var where = {
+    used: false,
+    parameters: {}
+  }
+  function whereParameter (check, type) {
+    if (!_.isUndefined(check)) {
+      where.used = true
+      where.parameters[type] = check
+      return check
+    }
+    return false
+  }
+  return {
+    lean: function (cb) {
+      cb(null, query.lean ? autoParse(query.lean) : OPTIONS.lean)
+    },
+    gt: function (cb) {
+      cb(null, query.gt ? whereParameter(query.gt, '$gt') : OPTIONS.gt)
+    },
+    lt: function (cb) {
+      cb(null, query.lt ? whereParameter(query.lt, '$lt') : OPTIONS.lt)
+    },
+    gte: function (cb) {
+      cb(null, query.gte ? whereParameter(query.gte, '$gte') : OPTIONS.gte)
+    },
+    lte: function (cb) {
+      cb(null, query.lte ? whereParameter(query.lte, '$lte') : OPTIONS.lte)
+    },
+    in: function (cb) {
+      cb(null, query.in ? whereParameter(query.in, '$in') : OPTIONS.in)
+    },
+    ne: function (cb) {
+      cb(null, query.ne ? whereParameter(query.ne, '$ne') : OPTIONS.ne)
+    },
+    nin: function (cb) {
+      cb(null, query.nin ? whereParameter(query.nin, '$nin') : OPTIONS.nin)
+    },
+    regex: function (cb) {
+      cb(null, query.regex ? whereParameter(query.regex, '$regex') : OPTIONS.regex)
+    },
+    options: function (cb) {
+      cb(null, query.options ? whereParameter(query.options, '$options') : OPTIONS.options)
+    },
+    size: function (cb) {
+      cb(null, query.size ? whereParameter(query.size, '$size') : OPTIONS.size)
+    },
+    all: function (cb) {
+      cb(null, query.all ? whereParameter(query.all, '$all') : OPTIONS.all)
+    },
+    equals: function (cb) {
+      cb(null, query.equals ? whereParameter(query.equals, '$equals') : OPTIONS.equals)
+    },
+    find: function (cb) {
+      cb(null, query.find ? whereParameter(query.find, 'find') : OPTIONS.find)
+    },
+    or: function (cb) {
+      cb(null, query.or ? andOrNorParameter(query.or, '$or') : OPTIONS.or)
+    },
+    nor: function (cb) {
+      cb(null, query.nor ? andOrNorParameter(query.nor, '$nor') : OPTIONS.nor)
+    },
+    and: function (cb) {
+      cb(null, query.and ? andOrNorParameter(query.and, '$and') : OPTIONS.and)
+    },
+    aggregate: function (cb) {
+      cb(null, query.aggregate ? aggregateCheck(query.aggregate) : OPTIONS.aggregate)
+    },
+    populateId: function (cb) {
+      cb(null, query.populateId ? populateCheck.call(self, query.populateId, self.options, 'populateId') : OPTIONS.populateId) // models
+    },
+    populateItems: function (cb) {
+      cb(null, query.populateItems ? populateCheck.call(self, query.populateItems, self.options, 'populateItems') : OPTIONS.populateItems) // settings.schema
+    },
+    deepPopulate: function (cb) {
+      cb(null, query.deepPopulate ? query.deepPopulate : OPTIONS.deepPopulate) // add settings.schema check for deepPop
+    },
+    where: function (cb) {
+      cb(null, query.where || {})
+    },
+    whereParameters: function (cb) {
+      cb(null, where)
+    }
+  }
+}
+
+MongooseAdapter.afterParse = function (result, options) {
+  if (result.whereParameters.used) {
+    // result.where = result.whereParameters
+    // call function
+    if (!_.isArray(result.where)) {
+      result.where = util.whereObject(result.where, result.whereParameters.parameters, options.settings.schema)
+    } else {
+      result.where = util.whereObject(result.where[0] || '', result.whereParameters.parameters, options.settings.schema)
+      console.log('The Where selector appears to be the problem. Looks like we got a multiple wheres but expect a where')
+    }
+  }
+  delete result.whereParameters
+}
+
+MongooseAdapter.options = OPTIONS
+
+module.exports = MongooseAdapter

--- a/lib/adapters/sql.js
+++ b/lib/adapters/sql.js
@@ -1,0 +1,14 @@
+function SqlAdapter (query) {
+  return {
+    sql: function (cb) {
+      cb(null, null)
+    }
+  }
+}
+
+SqlAdapter.options = {
+  // Future Plan
+  and: true
+}
+
+module.exports = SqlAdapter

--- a/lib/options.js
+++ b/lib/options.js
@@ -8,40 +8,11 @@ module.exports = {
     skip: 0,
     select: ''
   },
-  mongoose: {
-    populateId: '',
-    populateItems: '',
-    limitToPopulateId: '',
-    limitToPopulateItems: '',
-    deepPopulate: '',
-    where: '',
-    gt: false,
-    gte: false,
-    lte: false,
-    lt: false,
-    in: false,
-    ne: false,
-    nin: false,
-    regex: false,
-    options: false,
-    size: false,
-    all: false,
-    equals: false,
-    find: false,
-    or: false,
-    nor: false,
-    and: false
-  },
-  sql: {
-    // Future Plan
-  },
   settings: {
     aggregate: false,
     errorMessage: '< Error',
     warningMessage: '< Warning',
     delete: [],
-    mongoose: false,
-    sql: false,
     schema: []
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,111 @@
+var _ = require('lodash')
+var autoParse = require('auto-parse')
+
+function whereObject (where, whereParameters, schema) {
+  var output = {}
+  output[where] = {}
+  _.forEach(whereParameters, function (n, key) {
+    if (key === '$equals') {
+      try {
+        output[where] = autoParse(n) // valueParser(settings.schemas[settings.modelNameCheck(_.replace(req.path, settings.options.routing.url, ''))].paths[where].instance, n)
+      } catch (err) {
+        console.log(where + '- The Where selector appears to be the problem', 'Where$equals', err)
+      }
+    } else if (key === 'find') {
+      if (schema.indexOf(where) !== -1) {
+        output[where] = autoParse(n) // new RegExp(_.escapeRegExp(autoParse(n)), 'i')
+      } else {
+        console.log(where + '- The Where Find is not in the schema - strict mode on ', 'WhereFind', 'err')
+      }
+    } else if (key === '$nin' || key === '$in' || key === '$all') {
+      try {
+        if (_.isArray(n)) {
+          if (schema.indexOf(where) !== -1) {
+            output[where][key] = autoParse(n)
+          } else {
+            console.log(where + '- The Where $nin $in $all is not in the schema - strict mode on ', 'Whereinall', 'err')
+          }
+        } else {
+          if (schema.indexOf(where) !== -1) {
+            output[where][key] = [autoParse(n)]
+          } else {
+            console.log(where + '- The Where $nin $in $all is not in the schema - strict mode on ', 'WhereEinall', 'err')
+          }
+        }
+      } catch (err) {
+        console.log(where + '- The Where selector appears to be the problem', 'Where-all', err)
+      }
+    } else {
+      output[where][key] = autoParse(n)
+    }
+  })
+
+  return output
+}
+
+function limitCheck (number, limit) {
+  number = number << 0
+  if (!number || number > limit || number === 0) {
+    number = limit
+  }
+  return number
+}
+
+function sortCheck (sort) {
+  // V Year  ^ Title        ^ ...
+  //   1995    Bob           2
+  //   1995    Bob           1
+  //   1995    Alice
+  //   1995    AAA
+  //
+  //   1993    Carol
+  //   1993    Bob
+  //
+  //   1992    Dave
+  //
+  // sort=year&sort=-title
+  //
+  // sort: ["year", "-title"]
+  // .sort([
+  //  ["year", 1],
+  //  ["title", -1]
+  // ])
+  if (_.isArray(sort)) {
+    return _.map(sort, function (current) {
+      var direction = 1
+      if (_.startsWith(current, '-')) {
+        direction = -1
+        current = current.slice(1)
+      }
+      return [current, direction]
+    })
+  }
+  return sort
+}
+
+function selectCheck (select, schema) {
+  var selected = {}
+  select = _.isArray(select) ? select : select.split(' ')
+
+  _.forEach(select, function (current) {
+    if (!_.includes(schema, current)) {
+      return
+    }
+
+    var enabled = 1
+    if (_.startsWith(current, '-')) {
+      enabled = 0
+      current = current.slice(1)
+    }
+    selected[current] = enabled
+  })
+
+  return selected
+}
+
+module.exports = {
+  whereObject: whereObject,
+  limitCheck: limitCheck,
+  sortCheck: sortCheck,
+  selectCheck: selectCheck
+}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   "dependencies": {
     "auto-parse": "^1.2.0",
     "lodash": "^4.5.1",
-    "run-auto": "^2.0.0",
     "set-or-get": "^1.2.4"
   },
   "devDependencies": {

--- a/test/mocha.test.js
+++ b/test/mocha.test.js
@@ -1,4 +1,14 @@
-var build = require('../index')({settings: {schema: ['name', 'title', 'content', 'roles'], mongoose: true}})
+var build = require('..')({
+  settings: {
+    schema: ['name', 'title', 'content', 'roles'],
+    adapter: 'mongoose'
+  // adapter: <object|string:supported adapter>
+  //             ^
+  //             |
+  //             object|string:supported adapter
+  }
+})
+
 var assert = require('chai').assert
 var _ = require('lodash')
 describe('Express Query Parameters', function () {
@@ -6,8 +16,7 @@ describe('Express Query Parameters', function () {
     it('Config', function () {
       var config = build.config()
       var defaults = _.cloneDeep(config.query)
-      if (config.settings.mongoose) _.merge(defaults, config.mongoose)
-      if (config.settings.sql) _.merge(defaults, config.sql)
+      _.merge(defaults, build.adapter.options)
       assert.deepEqual(build.parse(), defaults)
     })
     it('Filter', function () {


### PR DESCRIPTION
Modularize the Mongoose and SQL into adapters.


## Description

Create a nice interface for creating custom adapters while lazily load the default adapters (Mongoose and SQL).

## Motivation and Context
Allow people creating custom adapters and do not load what you don't use.

## How Has This Been Tested?
Tests were updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
